### PR TITLE
Fix CLI and enrichment bugs

### DIFF
--- a/localmodel/cli/main.py
+++ b/localmodel/cli/main.py
@@ -4,7 +4,10 @@ import os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.enrich_local import enrich_from_local_db
+# Import the enrichment function from the correct module.  The previous import
+# referenced a non-existent module and function (`enrich_local.enrich_from_local_db`).
+# This prevented the CLI from running at all.
+from core.enrichment import enrich_local
 from core.schema import validate_entry
 from core.scoring import score_indicator
 from core.utils import write_log
@@ -16,11 +19,13 @@ def main():
     )
     parser.add_argument("indicator", nargs="?", help="IOC to enrich (IP, domain, or hash)")
     parser.add_argument("--extract-iocs", help="Path to .json, .txt, .csv, or .yaml file to parse for IOCs")
-    parser.add_argument("--output", help="Where to save parsed IOCs (default: data/parsed_threats.json)")
+    parser.add_argument("--output", help="Where to save parsed IOCs (default: localmodel/data/parsed_threats.json)")
     args = parser.parse_args()
 
     if args.extract_iocs:
-        output_path = args.output or os.path.join("data", "parsed_threats.json")
+        base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        default_out = os.path.join(base_dir, "data", "parsed_threats.json")
+        output_path = args.output or default_out
         parse_file(args.extract_iocs, output_path)
         return
 
@@ -29,7 +34,7 @@ def main():
         return
 
     indicator = args.indicator.strip()
-    matches = enrich_from_local_db(indicator)
+    matches = enrich_local(indicator)
 
     if not matches:
         print(f"[!] No local intelligence found for: {indicator}")

--- a/localmodel/core/enrichment.py
+++ b/localmodel/core/enrichment.py
@@ -1,7 +1,11 @@
 import json
 import os
 
-DATA_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "local_threat_db.json")
+# Threat intelligence is stored in `threatdb.json` under the data directory.
+# The original path referenced `local_threat_db.json`, which does not exist and
+# causes enrichment to always report the database as missing.  Align the path
+# with the actual file name so enrichment works correctly.
+DATA_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "threatdb.json")
 
 def enrich_local(indicator):
     if not os.path.exists(DATA_PATH):

--- a/localmodel/core/ioc_parser.py
+++ b/localmodel/core/ioc_parser.py
@@ -2,7 +2,10 @@ import os
 import re
 import json
 import csv
-import yaml
+try:
+    import yaml
+except ImportError:  # PyYAML may not be installed in minimal environments
+    yaml = None
 from core.schema import validate_entry
 
 def detect_type(ioc):
@@ -40,8 +43,12 @@ def parse_file(filepath, output_path=None):
                 raw = json.load(f)
                 text = json.dumps(raw)
             elif filepath.endswith(".yaml") or filepath.endswith(".yml"):
-                raw = yaml.safe_load(f)
-                text = json.dumps(raw)
+                if yaml is None:
+                    # Fall back to plain text if PyYAML is unavailable
+                    text = f.read()
+                else:
+                    raw = yaml.safe_load(f)
+                    text = json.dumps(raw)
             elif filepath.endswith(".csv"):
                 reader = csv.reader(f)
                 lines = [" ".join(row) for row in reader]

--- a/localmodel/data/threatdb.json
+++ b/localmodel/data/threatdb.json
@@ -1,13 +1,10 @@
-/* This is an example JSON that should be used strictly as an example for data formatting.
-*/
-
 [
   {
     "indicator": "127.0.0.1",
     "type": "ipv4",
     "tags": ["botnet", "ransomware"],
     "confidence": "High",
-    "percentage": "85",
+    "weight": 85,
     "source": "Very Reliable Threat Source",
     "last_seen": "2025-06-20"
   }


### PR DESCRIPTION
## Summary
- correct enrichment database path and remove outdated comment in threat JSON
- update CLI to import the right module and set proper output paths
- make IOC parser tolerate missing PyYAML dependency

## Testing
- `python3 localmodel/cli/main.py 127.0.0.1`
- `python3 localmodel/cli/main.py --extract-iocs localmodel/data/threatdb.json`


------
https://chatgpt.com/codex/tasks/task_e_6862cdb2fc7c8323bf9c891613167a96