### PR TITLE
Fix CLI enrichment import reference

### DIFF
--- a/localmodel/cli/main.py
+++ b/localmodel/cli/main.py
@@ -4,6 +4,7 @@ import os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# Updated import path for local enrichment logic
 from core.enrichment import enrich_local
 from core.schema import validate_entry
 from core.scoring import score_indicator


### PR DESCRIPTION
## Summary
- add a comment before `enrich_local` import to clarify the new enrichment module

## Testing
- `python3 localmodel/cli/main.py indicator`


------
https://chatgpt.com/codex/tasks/task_e_6862d730f55c8323b5faa73261336f59