### PR TITLE
Add IOC type validation

### DIFF
--- a/localmodel/cli/main.py
+++ b/localmodel/cli/main.py
@@ -9,7 +9,7 @@ from core.enrichment import enrich_local
 from core.schema import validate_entry
 from core.scoring import score_indicator
 from core.utils import write_log
-from core.ioc_parser import parse_file
+from core.ioc_parser import parse_file, detect_type
 
 def main():
     parser = argparse.ArgumentParser(
@@ -32,6 +32,10 @@ def main():
         return
 
     indicator = args.indicator.strip()
+    if not detect_type(indicator):
+        print(f"[!] Unknown indicator type: {indicator}")
+        return
+
     matches = enrich_local(indicator)
 
     if not matches:


### PR DESCRIPTION
## Summary
- validate indicator input using `detect_type`
- abort enrichment when the indicator doesn't match a known IOC format

## Testing
- `python -m py_compile localmodel/cli/main.py localmodel/core/ioc_parser.py localmodel/core/enrichment.py`

------
https://chatgpt.com/codex/tasks/task_e_6862deb508e88323bb915300714f5a0c