### PR TITLE
Add data directory validation for parse_file output

### DIFF
--- a/localmodel/core/ioc_parser.py
+++ b/localmodel/core/ioc_parser.py
@@ -76,12 +76,26 @@ def parse_file(filepath, output_path=None):
                 ioc_list.append(ioc_entry)
 
     if output_path:
-        try:
-            with open(output_path, "w", encoding="utf-8") as out:
-                json.dump(ioc_list, out, indent=2)
-                print(f"[+] Parsed IOCs written to: {output_path}")
-        except Exception as e:
-            print(f"[!] Failed to write output: {e}")
+        data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
+        normalized = os.path.normpath(output_path)
+        out_abs = os.path.abspath(output_path)
+
+        invalid = False
+        if ".." in normalized.split(os.sep):
+            print("[!] Invalid output path: directory traversal detected")
+            invalid = True
+        elif not out_abs.startswith(data_dir + os.sep):
+            print(f"[!] Output path must be within the data directory: {data_dir}")
+            invalid = True
+
+        if not invalid:
+            try:
+                os.makedirs(os.path.dirname(out_abs), exist_ok=True)
+                with open(out_abs, "w", encoding="utf-8") as out:
+                    json.dump(ioc_list, out, indent=2)
+                    print(f"[+] Parsed IOCs written to: {out_abs}")
+            except Exception as e:
+                print(f"[!] Failed to write output: {e}")
 
     return ioc_list
 


### PR DESCRIPTION
## Summary
- restrict `ioc_parser.parse_file` output paths to the local `data` directory
- print clear errors when an invalid output path is provided

## Testing
- `python -m compileall -q localmodel`

------
https://chatgpt.com/codex/tasks/task_e_6862dec0b1dc8323a0e8df8ac8b7a87a